### PR TITLE
Add basic command line interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 *.swp
 .DS_Store
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["paritydb", "benchmarks"]
+members = ["paritydb", "benchmarks", "cli"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "paritydb-cli"
+version = "0.1.0"
+authors = ["Guanqun Lu <guanqun.lu@gmail.com>"]
+
+[dependencies]
+paritydb = { path = "../paritydb" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 authors = ["Guanqun Lu <guanqun.lu@gmail.com>"]
 
 [dependencies]
+clap = "~2.26.0"
 paritydb = { path = "../paritydb" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,6 +15,23 @@ fn read_parameters<'a>(matches: &'a ArgMatches) -> Result<(&'a str, &'a str, Opt
 	}
 }
 
+fn do_get(db: &str, key: &str) -> Result<(), Error> {
+	let db = Database::open(db, Options::default())?;
+	let ret = db.get(key);
+	match ret {
+		Ok(Some(value)) => {
+			println!("value: {:?}", value);
+		},
+		Ok(None) => {
+			println!("value not found.");
+		},
+		Err(err) => {
+			println!("no value found for this key with error: {:?}.", err);
+		}
+	}
+	Ok(())
+}
+
 fn do_insert(db: &str, key: &str, value: &str) -> Result<(), Error> {
 	let mut db = Database::open(db, Options::default())
 				.or(Database::create(db, Options::default()))?;
@@ -40,6 +57,16 @@ fn main() {
 			.version("0.1.0")
 			.author("Parity Technology")
 			.about("A simple command line interface for ParityDB")
+			.subcommand(SubCommand::with_name("get")
+				.about("Get value from the specified key in database")
+				.arg(Arg::with_name("KEY")
+					.short("k")
+					.long("key")
+					.takes_value(true))
+				.arg(Arg::with_name("DB")
+					.short("d")
+					.long("db")
+					.takes_value(true)))
 			.subcommand(SubCommand::with_name("insert")
 				.about("Insert key to database")
 				.arg(Arg::with_name("KEY")
@@ -67,6 +94,13 @@ fn main() {
 			.get_matches();
 
 	match matches.subcommand() {
+		("get", Some(sub_m)) => {
+			if let Ok((db, key, _)) = read_parameters(&sub_m) {
+				do_get(db, key).expect("execute get error");
+			} else {
+				println!("errors for get.");
+			}
+		},
 		("insert", Some(sub_m)) => {
 			if let Ok((db, key, Some(value))) = read_parameters(&sub_m) {
 				do_insert(db, key, value).expect("execute insert error.");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,86 @@
+extern crate clap;
+extern crate paritydb;
+
+use clap::{Arg, ArgMatches, App, SubCommand};
+use paritydb::{Database, Error, Options, Transaction};
+
+fn read_parameters<'a>(matches: &'a ArgMatches) -> Result<(&'a str, &'a str, Option<&'a str>), ()>{
+	match (matches.value_of("DB"), matches.value_of("KEY")) {
+		(Some(db), Some(key)) => {
+			Ok((db, key, matches.value_of("VALUE")))
+		},
+		_ => {
+			Err(())
+		}
+	}
+}
+
+fn do_insert(db: &str, key: &str, value: &str) -> Result<(), Error> {
+	let mut db = Database::open(db, Options::default())
+				.or(Database::create(db, Options::default()))?;
+	let mut tx = Transaction::default();
+	tx.insert(key, value);
+	db.commit(&tx)?;
+	db.flush_journal(1)?;
+	Ok(())
+}
+
+fn do_delete(db: &str, key: &str) -> Result<(), Error> {
+	let mut db = Database::open(db, Options::default())?;
+	let mut tx = Transaction::default();
+	tx.delete(key);
+	db.commit(&tx)?;
+	db.flush_journal(1)?;
+	Ok(())
+}
+
 fn main() {
-    println!("Hello, world!");
+	let matches =
+		App::new("paritydb-cli")
+			.version("0.1.0")
+			.author("Parity Technology")
+			.about("A simple command line interface for ParityDB")
+			.subcommand(SubCommand::with_name("insert")
+				.about("Insert key to database")
+				.arg(Arg::with_name("KEY")
+					.short("k")
+					.long("key")
+					.takes_value(true))
+				.arg(Arg::with_name("VALUE")
+					.short("v")
+					.long("value")
+					.takes_value(true))
+				.arg(Arg::with_name("DB")
+					.short("d")
+					.long("db")
+					.takes_value(true)))
+			.subcommand(SubCommand::with_name("delete")
+				.about("Delete key in database")
+				.arg(Arg::with_name("KEY")
+					.short("k")
+					.long("key")
+					.takes_value(true))
+				.arg(Arg::with_name("DB")
+					.short("d")
+					.long("db")
+					.takes_value(true)))
+			.get_matches();
+
+	match matches.subcommand() {
+		("insert", Some(sub_m)) => {
+			if let Ok((db, key, Some(value))) = read_parameters(&sub_m) {
+				do_insert(db, key, value).expect("execute insert error.");
+			} else {
+				println!("errors for insert.");
+			}
+		},
+		("delete", Some(sub_m)) => {
+			if let Ok((db, key, _)) = read_parameters(&sub_m) {
+				do_delete(db, key).expect("execute delete error.");
+			} else {
+				println!("errors for delete");
+			}
+		},
+		_ => {}
+	}
 }

--- a/paritydb/src/database.rs
+++ b/paritydb/src/database.rs
@@ -65,6 +65,10 @@ impl Database {
 	/// Creates new database at given location.
 	pub fn create<P: AsRef<Path>>(path: P, options: Options) -> Result<Self> {
 		let options = InternalOptions::from_external(options)?;
+
+		// Create directories if necessary.
+		fs::create_dir_all(&path)?;
+
 		// Create DB file.
 		{
 			let db_file_path = path.as_ref().join(Self::DB_FILE);


### PR DESCRIPTION
So the following commands can work:

```
./target/debug/paritydb-cli insert -k helloworhelloworhelloworhellowor -v world -d testdb
./target/debug/paritydb-cli get -k helloworhelloworhelloworhellowor -d testdb
```
The last command would show
```
value: Raw([119, 111, 114, 108, 100])
```

Currently it's rather basic, but we can add more features to it.

And it fixes two issues:
https://github.com/debris/paritydb/pull/31/commits/9c00030cab32e96882bd915261e788b1898c6010 creates all directories in that path.
https://github.com/debris/paritydb/pull/31/commits/f66caa293903524dfb032f5ff81b350103c1f4b7 fixes the era index handling if the path name contains a directory in front of the file name.