### PR TITLE
Store Record key as slice

### DIFF
--- a/paritydb/src/database.rs
+++ b/paritydb/src/database.rs
@@ -331,10 +331,10 @@ impl<'a> Iterator for DatabaseIterator<'a> {
 					};
 				},
 				(IteratorValue::None, IteratorValue::DB(r)) => {
-					return Some(Ok((r.key_raw_slice(), Value::from(r))));
+					return Some(Ok((r.key(), Value::from(r))));
 				},
 				(IteratorValue::Journal(o), IteratorValue::DB(r)) => {
-					let ord = r.key_cmp(o.key()).expect(
+					let ord = r.key().partial_cmp(o.key()).expect(
 						"only returns None when compared keys don't have the same size; \
 						 all keys should have the same size; qed");
 
@@ -355,7 +355,7 @@ impl<'a> Iterator for DatabaseIterator<'a> {
 						},
 						Ordering::Less => {
 							self.pending = IteratorValue::Journal(o);
-							return Some(Ok((r.key_raw_slice(), Value::from(r))));
+							return Some(Ok((r.key(), Value::from(r))));
 						},
 					};
 				},

--- a/paritydb/src/find.rs
+++ b/paritydb/src/find.rs
@@ -132,10 +132,8 @@ mod tests {
 
 	fn expect_record(a: RecordResult, key: &[u8], value: &[u8]) {
 		if let RecordResult::Found(record) = a {
-			let mut k = Vec::new();
-			k.resize(key.len(), 0);
-			record.read_key(&mut k);
-			assert!(record.key_is_equal(key), "Invalid key. Expected: {:?}, got: {:?}", key, k);
+			let k = record.key();
+			assert_eq!(k, key, "Invalid key. Expected: {:?}, got: {:?}", key, k);
 
 			let mut v = Vec::new();
 			v.resize(value.len(), 0);
@@ -230,10 +228,7 @@ mod tests {
 
 		let keys: Vec<_> = records.map(|record| {
 			let record = record.unwrap();
-			let mut v = Vec::with_capacity(key_size);
-			v.resize(key_size, 0);
-			record.read_key(&mut v);
-			v
+			record.key().to_vec()
 		}).collect();
 
 		assert_eq!(

--- a/paritydb/src/record/record.rs
+++ b/paritydb/src/record/record.rs
@@ -114,22 +114,20 @@ mod tests {
 			1, 0xfa, 0xfb, 0xfc, 1, 2, 3, 4, 5,
 			1, 0xfd, 0xfe, 0xff, 6, 7, 8, 9, 10,
 		];
-		let mut key = [0; 3];
-		let mut value = [0; 5];
-
 
 		let record = Record::new(&data, body_size, value_size, key_size);
-		record.read_key(&mut key);
+		let key = record.key();
 		assert_eq!(key, [0xfa, 0xfb, 0xfc]);
-		assert!(record.key_is_equal(&key));
+
+		let mut value = [0; 5];
 		assert_eq!(record.value_len(), 5);
 		record.read_value(&mut value);
 		assert_eq!(value, [1, 2, 3, 4, 5]);
 
 		let record = Record::new(&data[body_size + field::HEADER_SIZE..], body_size, value_size, key_size);
-		record.read_key(&mut key);
+		let key = record.key();
 		assert_eq!(key, [0xfd, 0xfe, 0xff]);
-		assert!(record.key_is_equal(&key));
+
 		assert_eq!(record.value_len(), 5);
 		record.read_value(&mut value);
 		assert_eq!(value, [6, 7, 8, 9, 10]);
@@ -144,22 +142,21 @@ mod tests {
 			1, 0xfa, 0xfb, 3, 0, 0, 0, 1, 2, 3, 99,
 			1, 0xfc, 0xfd, 1, 0, 0, 0, 4, 0, 0, 0,
 		];
-		let mut key = [0; 2];
 		let mut value1 = [0; 3];
 		let mut value2 = [0; 1];
 
 		let record1 = Record::new(&data, body_size, value_size, key_size);
-		record1.read_key(&mut key);
-		assert_eq!(key, [0xfa, 0xfb]);
-		assert!(record1.key_is_equal(&key));
+		let key1 = record1.key();
+		assert_eq!(key1, [0xfa, 0xfb]);
+
 		assert_eq!(record1.value_len(), 3);
 		record1.read_value(&mut value1);
 		assert_eq!(value1, [1, 2, 3]);
 
 		let record2 = Record::new(&data[body_size + field::HEADER_SIZE..], body_size, value_size, key_size);
-		record2.read_key(&mut key);
-		assert_eq!(key, [0xfc, 0xfd]);
-		assert!(record2.key_is_equal(&key));
+		let key2 = record2.key();
+		assert_eq!(key2, [0xfc, 0xfd]);
+
 		assert_eq!(record2.value_len(), 1);
 		record2.read_value(&mut value2);
 		assert_eq!(value2, [4]);


### PR DESCRIPTION
We always initialize fields to be big enough to contain the key. This PR refactors `Record` to store the key as `&[u8]` instead of a `FieldView`.

The `field_body_size` is currently not exposed to the users (it's initialized in `InternalOptions`) and is set as `external.key_len + external.value_len.size()`. `Record::new` also asserts that `key_size <= field_body_size`.

Fixes #38.