### PR TITLE
Mark log/journal slice as Send and Sync

### DIFF
--- a/paritydb/src/collision.rs
+++ b/paritydb/src/collision.rs
@@ -244,6 +244,8 @@ struct LogSlice {
 	len: usize,
 }
 
+// LogEntry wraps a normal [u8] slice and allow viewing of the underlying `Mmap`. Both are Send and Sync, so the marker
+// here are safe.
 unsafe impl Send for LogSlice { }
 unsafe impl Sync for LogSlice { }
 

--- a/paritydb/src/collision.rs
+++ b/paritydb/src/collision.rs
@@ -244,6 +244,9 @@ struct LogSlice {
 	len: usize,
 }
 
+unsafe impl Send for LogSlice { }
+unsafe impl Sync for LogSlice { }
+
 impl Ord for LogSlice {
     fn cmp(&self, other: &Self) -> Ordering {
 		unsafe {

--- a/paritydb/src/journal.rs
+++ b/paritydb/src/journal.rs
@@ -21,6 +21,9 @@ enum JournalOperation<T> {
 	Delete,
 }
 
+unsafe impl Send for JournalSlice { }
+unsafe impl Sync for JournalSlice { }
+
 /// Unsafe view onto memmap file memory which backs journal.
 #[derive(Debug)]
 struct JournalSlice {

--- a/paritydb/src/journal.rs
+++ b/paritydb/src/journal.rs
@@ -21,6 +21,8 @@ enum JournalOperation<T> {
 	Delete,
 }
 
+// JournalSlice wraps a normal [u8] slice and allow viewing of the underlying `Mmap`. Both are Send and Sync, so the
+// marker here are safe.
 unsafe impl Send for JournalSlice { }
 unsafe impl Sync for JournalSlice { }
 


### PR DESCRIPTION
cc https://github.com/paritytech/parity/issues/7865

Looks like `LogSlice` and `JournalSlice` are just normal slice wrapper, and thus is `Send` and `Sync` safe.