### PR TITLE
Export DatabaseIterator

### DIFF
--- a/paritydb/src/database.rs
+++ b/paritydb/src/database.rs
@@ -463,6 +463,7 @@ impl<'a> IteratorValue<'a> {
 	}
 }
 
+/// Iterator over database key values.
 pub struct DatabaseIterator<'a> {
 	journal_iter: btree_set::IntoIter<Operation<'a>>,
 	record_collisions_iter: Box<Iterator<Item=Result<(&'a [u8], Value<'a>)>> + 'a>,

--- a/paritydb/src/lib.rs
+++ b/paritydb/src/lib.rs
@@ -84,7 +84,7 @@ mod record;
 mod space;
 mod transaction;
 
-pub use database::{Database, Value};
+pub use database::{Database, Value, DatabaseIterator};
 pub use error::{Error, Result, ErrorKind};
 pub use options::{Options, ValuesLen};
 pub use record::Record;


### PR DESCRIPTION
cc https://github.com/paritytech/parity/issues/7865

The `DatabaseIterator` type is already accessible via `Database::iter()`. However, the type itself is not exported, and prevents some legit usecase such as building a wrapping around it.